### PR TITLE
Modify parsing pattern for LanguageParser to include references preceeded by either a comma or an associative array

### DIFF
--- a/wire/modules/LanguageSupport/LanguageParser.php
+++ b/wire/modules/LanguageSupport/LanguageParser.php
@@ -228,7 +228,7 @@ class LanguageParser extends Wire {
 
 		// Find __('text', textdomain) style matches
 		preg_match_all(	
-			'/([\s.=(\\\\]__|^__)\(\s*' . // __(
+			'/([\s.=(\\\\,]__|=>__|^__)\(\s*' . // __(
 			'([\'"])(.+?)(?<!\\\\)\\2\s*' . // "text"
 			'(?:,\s*[^)]+)?\)+(.*)$/m', // , textdomain (optional) and everything else
 			$data, $matches[2]
@@ -236,7 +236,7 @@ class LanguageParser extends Wire {
 
 		// Find _x('text', 'context', textdomain) or $this->_x('text', 'context') style matches
 		preg_match_all(	
-			'/([\s.=>(\\\\]_x|^_x)\(\s*' . // _x( or $this->_x(
+			'/([\s.=>(\\\\,]_x|^_x)\(\s*' . // _x( or $this->_x(
 			'([\'"])(.+?)(?<!\\\\)\\2\s*,\s*' . // "text", 
 			'([\'"])(.+?)(?<!\\\\)\\4\s*' . // "context"
 			'[^)]*\)+(.*)$/m', // , textdomain (optional) and everything else 
@@ -245,7 +245,7 @@ class LanguageParser extends Wire {
 
 		// Find _n('singular text', 'plural text', $cnt, textdomain) or $this->_n(...) style matches
 		preg_match_all(	
-			'/([\s.=>(\\\\]_n|^_n)\(\s*' . // _n( or $this->_n(
+			'/([\s.=>(\\\\,]_n|^_n)\(\s*' . // _n( or $this->_n(
 			'([\'"])(.+?)(?<!\\\\)\\2\s*,\s*' . // "singular", 
 			'([\'"])(.+?)(?<!\\\\)\\4\s*,\s*' . // "plural", 
 			'.+?\)+(.*)$/m', // $count, optional textdomain, closing function parenthesis ) and rest of line


### PR DESCRIPTION
__('phrase') , _x('text', 'context', textdomain) and _n('singular text', 'plural text', $cnt, textdomain) now will also be parsed if they are preceeded either by a comma or an => as part of an associative array

